### PR TITLE
Refactor: Audio Engine Enhancements Phase 1

### DIFF
--- a/core/audio/audio_engine_server.py
+++ b/core/audio/audio_engine_server.py
@@ -54,6 +54,10 @@ class AudioEngine:
         self.ack_queue      = ack_queue
         self.shutdown_event = asyncio.Event()
         self._voices        = []
+        self.active_presets = []
+        self.current_melody = None
+        self.CLEANUP_INTERVAL = 1.0  # seconds
+        self._cleanup_task = None
 
         logger.info("initialising AudioEngineServer")
 
@@ -77,16 +81,83 @@ class AudioEngine:
         logger.debug("PRESETS_SIG params: %s",
                      {k: list(sig.parameters.keys()) for k, sig in self.presets_sig.items()})
         self.mute=False
+
+    async def _cleanup_stopped_presets(self):
+        logger.debug("Running _cleanup_stopped_presets")
+        # Iterate over a copy for safe removal
+        for preset_info in self.active_presets[:]: 
+            instance = preset_info.get("instance")
+            if not instance:
+                logger.warning("Preset_info missing 'instance': %s. Removing.", preset_info.get('name', 'Unknown'))
+                try:
+                    self.active_presets.remove(preset_info)
+                except ValueError: # Should not happen if iterating over a copy and item is from original
+                    logger.warning("Failed to remove preset_info that was already missing instance.")
+                continue
+
+            try:
+                # Assuming PyoObject has an isPlaying() method or similar.
+                # BasePreset is expected to provide access to the underlying PyoObject's state.
+                if hasattr(instance, 'isPlaying') and callable(instance.isPlaying):
+                    if not instance.isPlaying():
+                        logger.info("Preset '%s' is no longer playing. Removing.", preset_info["name"])
+                        self.active_presets.remove(preset_info)
+                elif hasattr(instance, 'getIsPlaying') and callable(instance.getIsPlaying): # Alternative common name
+                    if not instance.getIsPlaying():
+                        logger.info("Preset '%s' (using getIsPlaying) is no longer playing. Removing.", preset_info["name"])
+                        self.active_presets.remove(preset_info)
+                else:
+                    # If no direct isPlaying method, we might need other checks, 
+                    # or assume it's always active until explicitly stopped/replaced.
+                    # For now, log if the state cannot be determined.
+                    logger.debug("Preset '%s' does not have a recognized isPlaying/getIsPlaying method. Skipping cleanup for this item.", preset_info["name"])
+
+            except AttributeError as e:
+                logger.error(f"AttributeError checking if preset {preset_info['name']} is playing: {e}. Removing from active list.")
+                self.active_presets.remove(preset_info)
+            except Exception as e:
+                logger.error(f"Error checking if preset {preset_info['name']} is playing: {e}. Removing from active list.")
+                # Ensure removal if an unexpected error occurs during check, to prevent stuck presets
+                if preset_info in self.active_presets:
+                     self.active_presets.remove(preset_info)
+        logger.debug("Finished _cleanup_stopped_presets. Active presets count: %d", len(self.active_presets))
+
+
+    async def _periodic_cleanup_task(self):
+        while not self.shutdown_event.is_set():
+            await asyncio.sleep(self.CLEANUP_INTERVAL)
+            if self.shutdown_event.is_set(): # Re-check after sleep before cleanup
+                break
+            logger.debug("Periodic cleanup task waking up.")
+            await self._cleanup_stopped_presets()
+
     async def run(self):
         logger.info("server run loop started")
-        while not self.shutdown_event.is_set():
-            cmd = await self.cmd_queue.get()
-            logger.debug("run loop received cmd: %s", cmd)
-            try:
-                await self._handle(cmd)
-            finally:
-                self.cmd_queue.task_done()
+        self._cleanup_task = asyncio.create_task(self._periodic_cleanup_task())
 
+        while not self.shutdown_event.is_set():
+            try:
+                cmd = await self.cmd_queue.get()
+                logger.debug("run loop received cmd: %s", cmd)
+                try:
+                    await self._handle(cmd)
+                finally:
+                    self.cmd_queue.task_done()
+            except asyncio.CancelledError:
+                logger.info("Main run loop task cancelled.")
+                break # Exit loop if server task is cancelled
+
+        logger.info("Shutting down server...")
+        # Stop and cleanup the periodic task
+        if self._cleanup_task:
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                logger.info("Preset cleanup task successfully cancelled.")
+            except Exception as e:
+                logger.error(f"Exception during cleanup task shutdown: {e}")
+        
         # separate calls to avoid chaining None
         self.server.stop()
         self.server.shutdown()
@@ -105,11 +176,34 @@ class AudioEngine:
                 self._handle_set_tts(cmd)
             case "play_tts_direct":
                 self._handle_play_tts_direct(cmd)
+            case "get_active_presets":
+                await self._handle_get_active_presets(cmd)
+            case "get_current_melody":
+                await self._handle_get_current_melody(cmd)
             case "stop":
                 logger.debug("stop → shutting down")
                 self.shutdown_event.set()
             case other:
                 logger.warning("unhandled command: %r", other)
+
+    async def _handle_get_active_presets(self, cmd: Dict[str, Any]) -> None:
+        if not self.ack_queue:
+            logger.warning("ack_queue not available for get_active_presets")
+            return
+        serialized_presets = []
+        for preset_info in self.active_presets:
+            serialized_presets.append({
+                "name": preset_info["name"],
+                "params": preset_info["params"],
+                "instance": str(preset_info["instance"])  # Convert PyoObject to string
+            })
+        await self.ack_queue.put({"ack": "get_active_presets", "data": serialized_presets})
+
+    async def _handle_get_current_melody(self, cmd: Dict[str, Any]) -> None:
+        if not self.ack_queue:
+            logger.warning("ack_queue not available for get_current_melody")
+            return
+        await self.ack_queue.put({"ack": "get_current_melody", "data": self.current_melody})
 
     async def _handle_play_preset(self, cmd: Dict[str, Any]) -> None:
         name, params = cmd["preset"], cmd.get("params", {})
@@ -127,6 +221,7 @@ class AudioEngine:
         t0 = time.perf_counter()
         obj = cls(**init_args).play()
         self._voices.append(obj)
+        self.active_presets.append({"name": name, "params": init_args, "instance": obj})
         dt = (time.perf_counter() - t0) * 1000
         logger.info("▶ %s %s (%.1f ms)", name, init_args, dt)
 
@@ -135,7 +230,8 @@ class AudioEngine:
 
     async def _handle_play_block(self, cmd: Dict[str, Any]) -> None:
         events = cmd.get("events", [])
-        logger.debug("  play_block → scheduling %d events", len(events))
+        self.current_melody = cmd.get("name", "custom_melody")
+        logger.debug("  play_block → scheduling %d events for melody: %s", len(events), self.current_melody)
         asyncio.create_task(self._process_block_events(events))
 
     def _handle_play_tts(self, cmd: Dict[str, Any]) -> None:

--- a/core/audio/melodies/Christians_awake.json
+++ b/core/audio/melodies/Christians_awake.json
@@ -4,32 +4,154 @@
   "key": "G major",
   "tempo": 100,
   "time_signature": "4/4",
-  "notes": [
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1},
-    {"pitch":"B4","frequency":493.88,"duration_beats":2},
-    {"pitch":"C5","frequency":523.25,"duration_beats":1},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":2},
-
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},
-    {"pitch":"D4","frequency":293.66,"duration_beats":2},
-    
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},
-    {"pitch":"F#4","frequency":369.99,"duration_beats":1},
-    {"pitch":"G4","frequency":392.00,"duration_beats":2},
-
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},
-    {"pitch":"C5","frequency":523.25,"duration_beats":1},
-    {"pitch":"D5","frequency":587.33,"duration_beats":2},
-
-    {"pitch":"C5","frequency":523.25,"duration_beats":1},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":2},
-
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},
-    {"pitch":"G4","frequency":392.00,"duration_beats":2}
+  "created": "2024-01-01",
+  "mood": "Festive",
+  "description": "A traditional Christmas carol.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "4/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F#4",
+        "frequency": 369.99,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/Greensleeves.json
+++ b/core/audio/melodies/Greensleeves.json
@@ -4,12 +4,64 @@
   "key": "E minor",
   "tempo": 90,
   "time_signature": "6/8",
-  "notes": [
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},
-    {"pitch":"E5","frequency":659.25,"duration_beats":2},
-    {"pitch":"D5","frequency":587.33,"duration_beats":1},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1}
+  "created": "2024-01-01",
+  "mood": "Melancholic",
+  "description": "A traditional English folk song.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "6/8"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E5",
+        "frequency": 659.25,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/Greensleeves_Fast.json
+++ b/core/audio/melodies/Greensleeves_Fast.json
@@ -1,18 +1,18 @@
 {
-  "title": "The Blue Danube (waltz theme)",
-  "composer": "Johann Strauss II",
-  "key": "D major",
-  "tempo": 60,
-  "time_signature": "3/4",
+  "title": "Greensleeves (Fast Version)",
+  "composer": "Traditional",
+  "key": "E minor",
+  "tempo": 108,
+  "time_signature": "6/8",
   "created": "2024-01-01",
-  "mood": "Graceful",
-  "description": "The main waltz theme from 'The Blue Danube'.",
+  "mood": "Melancholic",
+  "description": "A traditional English folk song.",
   "poem": "N/A",
   "structure": [
     {
       "section": "A",
       "bars": 8,
-      "time_signature": "3/4"
+      "time_signature": "6/8"
     }
   ],
   "variations": 1,
@@ -27,38 +27,38 @@
   "hands": [
     [
       {
-        "pitch": "F#4",
-        "frequency": 369.99,
+        "pitch": "E4",
+        "frequency": 329.63,
         "duration_beats": 1,
         "intensity": 0.7
       },
       {
-        "pitch": "D4",
-        "frequency": 293.66,
+        "pitch": "G4",
+        "frequency": 392.0,
         "duration_beats": 1,
         "intensity": 0.7
       },
       {
-        "pitch": "B3",
-        "frequency": 246.94,
+        "pitch": "B4",
+        "frequency": 493.88,
         "duration_beats": 1,
         "intensity": 0.7
       },
       {
-        "pitch": "F#4",
-        "frequency": 369.99,
+        "pitch": "E5",
+        "frequency": 659.25,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
         "duration_beats": 1,
         "intensity": 0.7
       },
       {
-        "pitch": "D4",
-        "frequency": 293.66,
-        "duration_beats": 1,
-        "intensity": 0.7
-      },
-      {
-        "pitch": "B3",
-        "frequency": 246.94,
+        "pitch": "B4",
+        "frequency": 493.88,
         "duration_beats": 1,
         "intensity": 0.7
       }

--- a/core/audio/melodies/Gymnopedie_Quiet.json
+++ b/core/audio/melodies/Gymnopedie_Quiet.json
@@ -1,5 +1,5 @@
 {
-  "title": "Gymnopédie No. 1",
+  "title": "Gymnopédie (Quiet Version)",
   "composer": "Erik Satie",
   "key": "D major",
   "tempo": 60,
@@ -30,25 +30,25 @@
         "pitch": "G4",
         "frequency": 392.0,
         "duration_beats": 3,
-        "intensity": 0.7
+        "intensity": 0.49
       },
       {
         "pitch": "F#4",
         "frequency": 369.99,
         "duration_beats": 3,
-        "intensity": 0.7
+        "intensity": 0.49
       },
       {
         "pitch": "E4",
         "frequency": 329.63,
         "duration_beats": 3,
-        "intensity": 0.7
+        "intensity": 0.49
       },
       {
         "pitch": "D4",
         "frequency": 293.66,
         "duration_beats": 3,
-        "intensity": 0.7
+        "intensity": 0.49
       }
     ]
   ]

--- a/core/audio/melodies/Revolutionary_opening.json
+++ b/core/audio/melodies/Revolutionary_opening.json
@@ -4,22 +4,124 @@
   "key": "C minor",
   "tempo": 144,
   "time_signature": "2/4",
-  "notes": [
-    {"pitch":"C3","frequency":130.81,"duration_beats":0.5},
-    {"pitch":"C2","frequency":65.41,"duration_beats":0.5},
-    {"pitch":"C3","frequency":130.81,"duration_beats":0.5},
-    {"pitch":"C2","frequency":65.41,"duration_beats":0.5},
-    {"pitch":"C3","frequency":130.81,"duration_beats":0.5},
-    {"pitch":"C2","frequency":65.41,"duration_beats":0.5},
-    {"pitch":"C3","frequency":130.81,"duration_beats":0.5},
-    {"pitch":"C2","frequency":65.41,"duration_beats":0.5},
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"E♭4","frequency":311.13,"duration_beats":1},
-    {"pitch":"F4","frequency":349.23,"duration_beats":1},
-    {"pitch":"D♭4","frequency":277.18,"duration_beats":1},
-    {"pitch":"E♭4","frequency":311.13,"duration_beats":1},
-    {"pitch":"C4","frequency":261.63,"duration_beats":1},
-    {"pitch":"D♭4","frequency":277.18,"duration_beats":1},
-    {"pitch":"B3","frequency":246.94,"duration_beats":1}
+  "created": "2024-01-01",
+  "mood": "Dramatic",
+  "description": "The opening of Chopin's famous 'Revolutionary' Étude.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "2/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "C3",
+        "frequency": 130.81,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C2",
+        "frequency": 65.41,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C3",
+        "frequency": 130.81,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C2",
+        "frequency": 65.41,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C3",
+        "frequency": 130.81,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C2",
+        "frequency": 65.41,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C3",
+        "frequency": 130.81,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C2",
+        "frequency": 65.41,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E♭4",
+        "frequency": 311.13,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D♭4",
+        "frequency": 277.18,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E♭4",
+        "frequency": 311.13,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D♭4",
+        "frequency": 277.18,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 1,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/Rondo_d_Major.json
+++ b/core/audio/melodies/Rondo_d_Major.json
@@ -4,20 +4,112 @@
   "key": "D major",
   "tempo": 144,
   "time_signature": "12/8",
-  "notes": [
-    {"pitch":"D5","frequency":587.33,"duration_beats":1},
-    {"pitch":"F#5","frequency":739.99,"duration_beats":1},
-    {"pitch":"A5","frequency":880.00,"duration_beats":1},
-    {"pitch":"B5","frequency":987.77,"duration_beats":1},
-    {"pitch":"A5","frequency":880.00,"duration_beats":1},
-    {"pitch":"F#5","frequency":739.99,"duration_beats":1},
-    {"pitch":"D5","frequency":587.33,"duration_beats":1},
-    {"pitch":"C#5","frequency":554.37,"duration_beats":1},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1},
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"F#4","frequency":369.99,"duration_beats":1},
-    {"pitch":"E4","frequency":329.63,"duration_beats":2},
-    {"pitch":"D4","frequency":293.66,"duration_beats":2}
+  "created": "2024-01-01",
+  "mood": "Lively",
+  "description": "The theme from Mozart's Rondo in D Major, K. 485.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "12/8"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F#5",
+        "frequency": 739.99,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A5",
+        "frequency": 880.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B5",
+        "frequency": 987.77,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A5",
+        "frequency": 880.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F#5",
+        "frequency": 739.99,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C#5",
+        "frequency": 554.37,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F#4",
+        "frequency": 369.99,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 2,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/Shadow_descent.json
+++ b/core/audio/melodies/Shadow_descent.json
@@ -4,77 +4,754 @@
   "key": "D minor",
   "tempo": 72,
   "time_signature": "4/4",
-  "notes": [
-
-    {"pitch":"D3","frequency":146.83,"duration_beats":1},{"pitch":"A2","frequency":110.00,"duration_beats":1},
-    {"pitch":"D3","frequency":146.83,"duration_beats":1},{"pitch":"C3","frequency":130.81,"duration_beats":1},
-    {"pitch":"F3","frequency":174.61,"duration_beats":1},{"pitch":"D3","frequency":146.83,"duration_beats":1},
-    {"pitch":"F3","frequency":174.61,"duration_beats":1},{"pitch":"E3","frequency":164.81,"duration_beats":1},
-    {"pitch":"D4","frequency":293.66,"duration_beats":0.5},{"pitch":"C#4","frequency":277.18,"duration_beats":0.5},
-    {"pitch":"D4","frequency":293.66,"duration_beats":0.5},{"pitch":"C#4","frequency":277.18,"duration_beats":0.5},
-    {"pitch":"B3","frequency":246.94,"duration_beats":1},{"pitch":"A3","frequency":220.00,"duration_beats":1},
-    {"pitch":"G3","frequency":196.00,"duration_beats":2},
-
-    {"pitch":"A3","frequency":220.00,"duration_beats":0.5},{"pitch":"A#3","frequency":233.08,"duration_beats":0.5},
-    {"pitch":"B3","frequency":246.94,"duration_beats":0.5},{"pitch":"C4","frequency":261.63,"duration_beats":0.5},
-    {"pitch":"C#4","frequency":277.18,"duration_beats":0.5},{"pitch":"D4","frequency":293.66,"duration_beats":0.5},
-    {"pitch":"D#4","frequency":311.13,"duration_beats":0.5},{"pitch":"E4","frequency":329.63,"duration_beats":0.5},
-    {"pitch":"F4","frequency":349.23,"duration_beats":1},{"pitch":"E4","frequency":329.63,"duration_beats":1},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},{"pitch":"C4","frequency":261.63,"duration_beats":1},
-    {"pitch":"B3","frequency":246.94,"duration_beats":1},{"pitch":"A3","frequency":220.00,"duration_beats":1},
-    {"pitch":"G3","frequency":196.00,"duration_beats":2},
-
-    {"pitch":"D3","frequency":146.83,"duration_beats":0.5},{"pitch":"F3","frequency":174.61,"duration_beats":0.5},
-    {"pitch":"A3","frequency":220.00,"duration_beats":0.5},{"pitch":"C4","frequency":261.63,"duration_beats":0.5},
-    {"pitch":"D3","frequency":146.83,"duration_beats":0.5},{"pitch":"F3","frequency":174.61,"duration_beats":0.5},
-    {"pitch":"A3","frequency":220.00,"duration_beats":0.5},{"pitch":"C4","frequency":261.63,"duration_beats":0.5},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},{"pitch":"C#4","frequency":277.18,"duration_beats":1},
-    {"pitch":"B3","frequency":246.94,"duration_beats":1},{"pitch":"A3","frequency":220.00,"duration_beats":1},
-    {"pitch":"G3","frequency":196.00,"duration_beats":1},{"pitch":"F3","frequency":174.61,"duration_beats":1},
-    {"pitch":"E3","frequency":164.81,"duration_beats":2},
-
-    {"pitch":"D4","frequency":293.66,"duration_beats":0.5},{"pitch":"C4","frequency":261.63,"duration_beats":0.5},
-    {"pitch":"B3","frequency":246.94,"duration_beats":0.5},{"pitch":"A3","frequency":220.00,"duration_beats":0.5},
-    {"pitch":"G3","frequency":196.00,"duration_beats":0.5},{"pitch":"F3","frequency":174.61,"duration_beats":0.5},
-    {"pitch":"E3","frequency":164.81,"duration_beats":0.5},{"pitch":"D3","frequency":146.83,"duration_beats":0.5},
-    {"pitch":"C3","frequency":130.81,"duration_beats":1},{"pitch":"B2","frequency":123.47,"duration_beats":1},
-    {"pitch":"A2","frequency":110.00,"duration_beats":1},{"pitch":"G2","frequency":98.00,"duration_beats":1},
-    {"pitch":"F2","frequency":87.31,"duration_beats":1},{"pitch":"E2","frequency":82.41,"duration_beats":1},
-    {"pitch":"D2","frequency":73.42,"duration_beats":2},
-
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.25},{"pitch":"A1","frequency":55.00,"duration_beats":0.25},
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.25},{"pitch":"A1","frequency":55.00,"duration_beats":0.25},
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.25},{"pitch":"A1","frequency":55.00,"duration_beats":0.25},
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.25},{"pitch":"A1","frequency":55.00,"duration_beats":0.25},
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.25},{"pitch":"A1","frequency":55.00,"duration_beats":0.25},
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.25},{"pitch":"A1","frequency":55.00,"duration_beats":0.25},
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.25},{"pitch":"A1","frequency":55.00,"duration_beats":0.25},
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.25},{"pitch":"A1","frequency":55.00,"duration_beats":0.25},
-
-    {"pitch":"C5","frequency":523.25,"duration_beats":0.5},{"pitch":"B4","frequency":493.88,"duration_beats":0.5},
-    {"pitch":"A4","frequency":440.00,"duration_beats":0.5},{"pitch":"G#4","frequency":415.30,"duration_beats":0.5},
-    {"pitch":"A4","frequency":440.00,"duration_beats":0.5},{"pitch":"B4","frequency":493.88,"duration_beats":0.5},
-    {"pitch":"C5","frequency":523.25,"duration_beats":0.5},{"pitch":"B4","frequency":493.88,"duration_beats":0.5},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"F#4","frequency":369.99,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"F#4","frequency":369.99,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":1},
-
-    {"pitch":"D5","frequency":587.33,"duration_beats":0.5},{"pitch":"C#5","frequency":554.37,"duration_beats":0.5},
-    {"pitch":"B4","frequency":493.88,"duration_beats":0.5},{"pitch":"A4","frequency":440.00,"duration_beats":0.5},
-    {"pitch":"G4","frequency":392.00,"duration_beats":0.5},{"pitch":"F4","frequency":349.23,"duration_beats":0.5},
-    {"pitch":"E4","frequency":329.63,"duration_beats":0.5},{"pitch":"D4","frequency":293.66,"duration_beats":0.5},
-    {"pitch":"C4","frequency":261.63,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":1},
-    {"pitch":"A3","frequency":220.00,"duration_beats":1},{"pitch":"G3","frequency":196.00,"duration_beats":1},
-    {"pitch":"F3","frequency":174.61,"duration_beats":1},{"pitch":"E3","frequency":164.81,"duration_beats":1},
-    {"pitch":"D3","frequency":146.83,"duration_beats":2},
-
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.5},{"pitch":"Rest","frequency":0,"duration_beats":0.5},
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.5},{"pitch":"Rest","frequency":0,"duration_beats":0.5},
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.5},{"pitch":"Rest","frequency":0,"duration_beats":0.5},
-    {"pitch":"D2","frequency":73.42,"duration_beats":0.5},{"pitch":"Rest","frequency":0,"duration_beats":0.5},
-    {"pitch":"C2","frequency":65.41,"duration_beats":1},{"pitch":"Rest","frequency":0,"duration_beats":1},
-    {"pitch":"A1","frequency":55.00,"duration_beats":1},{"pitch":"Rest","frequency":0,"duration_beats":1},
-    {"pitch":"D2","frequency":73.42,"duration_beats":2},{"pitch":"Rest","frequency":0,"duration_beats":2}
+  "created": "2024-01-01",
+  "mood": "Dark",
+  "description": "An étude in D minor.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "4/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "D3",
+        "frequency": 146.83,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A2",
+        "frequency": 110.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D3",
+        "frequency": 146.83,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C3",
+        "frequency": 130.81,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F3",
+        "frequency": 174.61,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D3",
+        "frequency": 146.83,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F3",
+        "frequency": 174.61,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E3",
+        "frequency": 164.81,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C#4",
+        "frequency": 277.18,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C#4",
+        "frequency": 277.18,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A#3",
+        "frequency": 233.08,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C#4",
+        "frequency": 277.18,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D#4",
+        "frequency": 311.13,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D3",
+        "frequency": 146.83,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F3",
+        "frequency": 174.61,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D3",
+        "frequency": 146.83,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F3",
+        "frequency": 174.61,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C#4",
+        "frequency": 277.18,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F3",
+        "frequency": 174.61,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E3",
+        "frequency": 164.81,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F3",
+        "frequency": 174.61,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E3",
+        "frequency": 164.81,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D3",
+        "frequency": 146.83,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C3",
+        "frequency": 130.81,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B2",
+        "frequency": 123.47,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A2",
+        "frequency": 110.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G2",
+        "frequency": 98.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F2",
+        "frequency": 87.31,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E2",
+        "frequency": 82.41,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A1",
+        "frequency": 55.0,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A1",
+        "frequency": 55.0,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A1",
+        "frequency": 55.0,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A1",
+        "frequency": 55.0,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A1",
+        "frequency": 55.0,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A1",
+        "frequency": 55.0,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A1",
+        "frequency": 55.0,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A1",
+        "frequency": 55.0,
+        "duration_beats": 0.25,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G#4",
+        "frequency": 415.3,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F#4",
+        "frequency": 369.99,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F#4",
+        "frequency": 369.99,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C#5",
+        "frequency": 554.37,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F3",
+        "frequency": 174.61,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E3",
+        "frequency": 164.81,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D3",
+        "frequency": 146.83,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "Rest",
+        "frequency": 0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "Rest",
+        "frequency": 0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "Rest",
+        "frequency": 0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "Rest",
+        "frequency": 0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C2",
+        "frequency": 65.41,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "Rest",
+        "frequency": 0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A1",
+        "frequency": 55.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "Rest",
+        "frequency": 0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D2",
+        "frequency": 73.42,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "Rest",
+        "frequency": 0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/canon_D.json
+++ b/core/audio/melodies/canon_D.json
@@ -4,14 +4,76 @@
   "key": "D major",
   "tempo": 80,
   "time_signature": "4/4",
-  "notes": [
-    {"pitch":"D4","frequency":293.66,"duration_beats":4},
-    {"pitch":"A3","frequency":220.00,"duration_beats":4},
-    {"pitch":"B3","frequency":246.94,"duration_beats":4},
-    {"pitch":"F#3","frequency":185.00,"duration_beats":4},
-    {"pitch":"G3","frequency":196.00,"duration_beats":4},
-    {"pitch":"D3","frequency":146.83,"duration_beats":4},
-    {"pitch":"G3","frequency":196.00,"duration_beats":4},
-    {"pitch":"A3","frequency":220.00,"duration_beats":4}
+  "created": "2024-01-01",
+  "mood": "Flowing",
+  "description": "The ground bass of Pachelbel's Canon in D.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "4/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 4,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 4,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 4,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F#3",
+        "frequency": 185.0,
+        "duration_beats": 4,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 4,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D3",
+        "frequency": 146.83,
+        "duration_beats": 4,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 4,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 4,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/fur_elise.json
+++ b/core/audio/melodies/fur_elise.json
@@ -4,29 +4,154 @@
   "key": "A minor",
   "tempo": 120,
   "time_signature": "3/8",
-  "notes": [
-    {"pitch": "E5",  "frequency": 659.25, "duration_beats": 0.5},
-    {"pitch": "D#5", "frequency": 622.25, "duration_beats": 0.5},
-    {"pitch": "E5",  "frequency": 659.25, "duration_beats": 0.5},
-    {"pitch": "D#5", "frequency": 622.25, "duration_beats": 0.5},
-    {"pitch": "E5",  "frequency": 659.25, "duration_beats": 0.5},
-    {"pitch": "B4",  "frequency": 493.88, "duration_beats": 0.5},
-    {"pitch": "D5",  "frequency": 587.33, "duration_beats": 0.5},
-    {"pitch": "C5",  "frequency": 523.25, "duration_beats": 0.5},
-    {"pitch": "A4",  "frequency": 440.00, "duration_beats": 1.0},
-
-    {"pitch": "C4",  "frequency": 261.63, "duration_beats": 0.5},
-    {"pitch": "E4",  "frequency": 329.63, "duration_beats": 0.5},
-    {"pitch": "A4",  "frequency": 440.00, "duration_beats": 1.0},
-
-    {"pitch": "E5",  "frequency": 659.25, "duration_beats": 0.5},
-    {"pitch": "D#5", "frequency": 622.25, "duration_beats": 0.5},
-    {"pitch": "E5",  "frequency": 659.25, "duration_beats": 0.5},
-    {"pitch": "D#5", "frequency": 622.25, "duration_beats": 0.5},
-    {"pitch": "E5",  "frequency": 659.25, "duration_beats": 0.5},
-    {"pitch": "B4",  "frequency": 493.88, "duration_beats": 0.5},
-    {"pitch": "D5",  "frequency": 587.33, "duration_beats": 0.5},
-    {"pitch": "C5",  "frequency": 523.25, "duration_beats": 0.5},
-    {"pitch": "A4",  "frequency": 440.00, "duration_beats": 1.0}
+  "created": "2024-01-01",
+  "mood": "Sentimental",
+  "description": "A famous bagatelle by Ludwig van Beethoven.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "3/8"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "E5",
+        "frequency": 659.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D#5",
+        "frequency": 622.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E5",
+        "frequency": 659.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D#5",
+        "frequency": 622.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E5",
+        "frequency": 659.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1.0,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1.0,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E5",
+        "frequency": 659.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D#5",
+        "frequency": 622.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E5",
+        "frequency": 659.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D#5",
+        "frequency": 622.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E5",
+        "frequency": 659.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1.0,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/la_folia.json
+++ b/core/audio/melodies/la_folia.json
@@ -4,14 +4,76 @@
   "key": "D minor",
   "tempo": 110,
   "time_signature": "4/4",
-  "notes": [
-    {"pitch":"D4","frequency":293.66,"duration_beats":2},
-    {"pitch":"A4","frequency":440.00,"duration_beats":2},
-    {"pitch":"Bb4","frequency":466.16,"duration_beats":2},
-    {"pitch":"F4","frequency":349.23,"duration_beats":2},
-    {"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"D4","frequency":293.66,"duration_beats":2},
-    {"pitch":"C4","frequency":261.63,"duration_beats":2},
-    {"pitch":"A4","frequency":440.00,"duration_beats":2}
+  "created": "2024-01-01",
+  "mood": "Baroque",
+  "description": "A traditional baroque theme.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "4/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "Bb4",
+        "frequency": 466.16,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/minuet_G_Major.json
+++ b/core/audio/melodies/minuet_G_Major.json
@@ -4,15 +4,82 @@
   "key": "G major",
   "tempo": 90,
   "time_signature": "3/4",
-  "notes": [
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},
-    {"pitch":"C5","frequency":523.25,"duration_beats":1},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1},
-    {"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1}
+  "created": "2024-01-01",
+  "mood": "Elegant",
+  "description": "A well-known minuet often attributed to Bach, but composed by Christian Petzold.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "3/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/nocturne_E_FLat_Major.json
+++ b/core/audio/melodies/nocturne_E_FLat_Major.json
@@ -4,73 +4,748 @@
   "key": "E♭ major",
   "tempo": 60,
   "time_signature": "12/8",
-  "notes": [
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-    {"pitch":"G3","frequency":196.00,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-    {"pitch":"G3","frequency":196.00,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-
-    {"pitch":"C5","frequency":523.25,"duration_beats":1},{"pitch":"A4","frequency":440.00,"duration_beats":2},
-    {"pitch":"F4","frequency":349.23,"duration_beats":1},{"pitch":"A4","frequency":440.00,"duration_beats":2},
-    {"pitch":"C5","frequency":523.25,"duration_beats":1},{"pitch":"A4","frequency":440.00,"duration_beats":2},
-    {"pitch":"F4","frequency":349.23,"duration_beats":1},{"pitch":"A4","frequency":440.00,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-    {"pitch":"A3","frequency":220.00,"duration_beats":1},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-    {"pitch":"A3","frequency":220.00,"duration_beats":1},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-    {"pitch":"G3","frequency":196.00,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-    {"pitch":"G3","frequency":196.00,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-
-    {"pitch":"C5","frequency":523.25,"duration_beats":1},{"pitch":"A4","frequency":440.00,"duration_beats":2},
-    {"pitch":"F4","frequency":349.23,"duration_beats":1},{"pitch":"A4","frequency":440.00,"duration_beats":2},
-    {"pitch":"C5","frequency":523.25,"duration_beats":1},{"pitch":"A4","frequency":440.00,"duration_beats":2},
-    {"pitch":"F4","frequency":349.23,"duration_beats":1},{"pitch":"A4","frequency":440.00,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-    {"pitch":"A3","frequency":220.00,"duration_beats":1},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-    {"pitch":"A3","frequency":220.00,"duration_beats":1},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-
-    {"pitch":"G3","frequency":196.00,"duration_beats":0.5},{"pitch":"G2","frequency":98.00,"duration_beats":0.5},
-    {"pitch":"G3","frequency":196.00,"duration_beats":0.5},{"pitch":"G2","frequency":98.00,"duration_beats":0.5},
-    {"pitch":"G3","frequency":196.00,"duration_beats":0.5},{"pitch":"G2","frequency":98.00,"duration_beats":0.5},
-    {"pitch":"G3","frequency":196.00,"duration_beats":0.5},{"pitch":"G2","frequency":98.00,"duration_beats":0.5},
-    {"pitch":"C4","frequency":261.63,"duration_beats":1},{"pitch":"A3","frequency":220.00,"duration_beats":1},
-    {"pitch":"F3","frequency":174.61,"duration_beats":1},{"pitch":"A3","frequency":220.00,"duration_beats":1},
-    {"pitch":"C4","frequency":261.63,"duration_beats":1},{"pitch":"A3","frequency":220.00,"duration_beats":1},
-    {"pitch":"F3","frequency":174.61,"duration_beats":1},{"pitch":"A3","frequency":220.00,"duration_beats":1},
-
-    {"pitch":"D5","frequency":587.33,"duration_beats":0.5},{"pitch":"C5","frequency":523.25,"duration_beats":0.5},
-    {"pitch":"B4","frequency":493.88,"duration_beats":0.5},{"pitch":"C5","frequency":523.25,"duration_beats":0.5},
-    {"pitch":"D5","frequency":587.33,"duration_beats":0.5},{"pitch":"C5","frequency":523.25,"duration_beats":0.5},
-    {"pitch":"B4","frequency":493.88,"duration_beats":0.5},{"pitch":"C5","frequency":523.25,"duration_beats":0.5},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"F4","frequency":349.23,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"F4","frequency":349.23,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":1},
-
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},{"pitch":"G4","frequency":392.00,"duration_beats":2},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-    {"pitch":"G3","frequency":196.00,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-    {"pitch":"G3","frequency":196.00,"duration_beats":1},{"pitch":"B3","frequency":246.94,"duration_beats":2},
-
-    {"pitch":"E4","frequency":329.63,"duration_beats":2},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-    {"pitch":"A3","frequency":220.00,"duration_beats":2},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-    {"pitch":"E4","frequency":329.63,"duration_beats":2},{"pitch":"C4","frequency":261.63,"duration_beats":2},
-    {"pitch":"A3","frequency":220.00,"duration_beats":2},{"pitch":"C4","frequency":261.63,"duration_beats":2}
+  "created": "2024-01-01",
+  "mood": "Romantic",
+  "description": "A famous nocturne by Frédéric Chopin.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "12/8"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G2",
+        "frequency": 98.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G2",
+        "frequency": 98.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G2",
+        "frequency": 98.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G2",
+        "frequency": 98.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F3",
+        "frequency": 174.61,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F3",
+        "frequency": 174.61,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G3",
+        "frequency": 196.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B3",
+        "frequency": 246.94,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A3",
+        "frequency": 220.0,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/ode_to_joy.json
+++ b/core/audio/melodies/ode_to_joy.json
@@ -4,20 +4,112 @@
   "key": "D major",
   "tempo": 100,
   "time_signature": "4/4",
-  "notes": [
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},
-    {"pitch":"F#4","frequency":369.99,"duration_beats":1},
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"F#4","frequency":369.99,"duration_beats":1},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},
-    {"pitch":"C4","frequency":261.63,"duration_beats":1},
-    {"pitch":"C4","frequency":261.63,"duration_beats":1},
-    {"pitch":"D4","frequency":293.66,"duration_beats":1},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},
-    {"pitch":"E4","frequency":329.63,"duration_beats":1.5},
-    {"pitch":"D4","frequency":293.66,"duration_beats":0.5}
+  "created": "2024-01-01",
+  "mood": "Joyful",
+  "description": "The theme from Beethoven's 9th Symphony, 'Ode to Joy'.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "4/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F#4",
+        "frequency": 369.99,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F#4",
+        "frequency": 369.99,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/prelude_C_Major.json
+++ b/core/audio/melodies/prelude_C_Major.json
@@ -4,14 +4,76 @@
   "key": "C major",
   "tempo": 120,
   "time_signature": "4/4",
-  "notes": [
-    {"pitch":"C4","frequency":261.63,"duration_beats":0.5},
-    {"pitch":"E4","frequency":329.63,"duration_beats":0.5},
-    {"pitch":"G4","frequency":392.00,"duration_beats":0.5},
-    {"pitch":"C5","frequency":523.25,"duration_beats":0.5},
-    {"pitch":"B4","frequency":493.88,"duration_beats":0.5},
-    {"pitch":"G4","frequency":392.00,"duration_beats":0.5},
-    {"pitch":"E4","frequency":329.63,"duration_beats":0.5},
-    {"pitch":"C4","frequency":261.63,"duration_beats":0.5}
+  "created": "2024-01-01",
+  "mood": "Flowing",
+  "description": "A famous prelude from Bach's Well-Tempered Clavier.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "4/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C4",
+        "frequency": 261.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/prelude_D_minor.json
+++ b/core/audio/melodies/prelude_D_minor.json
@@ -4,22 +4,124 @@
   "key": "D minor",
   "tempo": 100,
   "time_signature": "4/4",
-  "notes": [
-    {"pitch":"D4","frequency":293.66,"duration_beats":0.5},
-    {"pitch":"F4","frequency":349.23,"duration_beats":0.5},
-    {"pitch":"A4","frequency":440.00,"duration_beats":0.5},
-    {"pitch":"D5","frequency":587.33,"duration_beats":0.5},
-    {"pitch":"C5","frequency":523.25,"duration_beats":0.5},
-    {"pitch":"A4","frequency":440.00,"duration_beats":0.5},
-    {"pitch":"F4","frequency":349.23,"duration_beats":0.5},
-    {"pitch":"D4","frequency":293.66,"duration_beats":0.5},
-    {"pitch":"E4","frequency":329.63,"duration_beats":0.5},
-    {"pitch":"G4","frequency":392.00,"duration_beats":0.5},
-    {"pitch":"B♭4","frequency":466.16,"duration_beats":0.5},
-    {"pitch":"D5","frequency":587.33,"duration_beats":0.5},
-    {"pitch":"C5","frequency":523.25,"duration_beats":0.5},
-    {"pitch":"A4","frequency":440.00,"duration_beats":0.5},
-    {"pitch":"F4","frequency":349.23,"duration_beats":0.5},
-    {"pitch":"D4","frequency":293.66,"duration_beats":0.5}
+  "created": "2024-01-01",
+  "mood": "Baroque",
+  "description": "A prelude from Bach's Well-Tempered Clavier.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "4/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B♭4",
+        "frequency": 466.16,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C5",
+        "frequency": 523.25,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F4",
+        "frequency": 349.23,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D4",
+        "frequency": 293.66,
+        "duration_beats": 0.5,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/scarborough_fair.json
+++ b/core/audio/melodies/scarborough_fair.json
@@ -4,13 +4,70 @@
   "key": "E minor",
   "tempo": 85,
   "time_signature": "3/4",
-  "notes": [
-    {"pitch":"E4","frequency":329.63,"duration_beats":1},
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1},
-    {"pitch":"B4","frequency":493.88,"duration_beats":1},
-    {"pitch":"A4","frequency":440.00,"duration_beats":1},
-    {"pitch":"G4","frequency":392.00,"duration_beats":1},
-    {"pitch":"E4","frequency":329.63,"duration_beats":2}
+  "created": "2024-01-01",
+  "mood": "Folk",
+  "description": "The melody of the traditional English ballad 'Scarborough Fair'.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "3/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "B4",
+        "frequency": 493.88,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A4",
+        "frequency": 440.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "G4",
+        "frequency": 392.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "E4",
+        "frequency": 329.63,
+        "duration_beats": 2,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/melodies/walt_of_the_flowers.json
+++ b/core/audio/melodies/walt_of_the_flowers.json
@@ -4,11 +4,58 @@
   "key": "D major",
   "tempo": 120,
   "time_signature": "3/4",
-  "notes": [
-    {"pitch":"D5","frequency":587.33,"duration_beats":1},
-    {"pitch":"F#5","frequency":739.99,"duration_beats":1},
-    {"pitch":"A5","frequency":880.00,"duration_beats":1},
-    {"pitch":"D6","frequency":1174.66,"duration_beats":2},
-    {"pitch":"C6","frequency":1046.50,"duration_beats":1}
+  "created": "2024-01-01",
+  "mood": "Magical",
+  "description": "A famous waltz from Tchaikovsky's ballet 'The Nutcracker'.",
+  "poem": "N/A",
+  "structure": [
+    {
+      "section": "A",
+      "bars": 8,
+      "time_signature": "3/4"
+    }
+  ],
+  "variations": 1,
+  "remix": {
+    "self_shuffle": 0.0,
+    "exchange_ratio_range": [
+      0.0,
+      0.0
+    ],
+    "transition_blocks": 0
+  },
+  "hands": [
+    [
+      {
+        "pitch": "D5",
+        "frequency": 587.33,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "F#5",
+        "frequency": 739.99,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "A5",
+        "frequency": 880.0,
+        "duration_beats": 1,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "D6",
+        "frequency": 1174.66,
+        "duration_beats": 2,
+        "intensity": 0.7
+      },
+      {
+        "pitch": "C6",
+        "frequency": 1046.5,
+        "duration_beats": 1,
+        "intensity": 0.7
+      }
+    ]
   ]
 }

--- a/core/audio/presets/bass.py
+++ b/core/audio/presets/bass.py
@@ -9,35 +9,39 @@ class Bass(BasePreset):
         self,
         intensity=0.98,
         duration=0.65,
-        base_freq=1318.2567385564075,
-        fade_in=0.0,
-        fade_out=0.0,
-        tone_freq_ratio=223.872113856834,
+        base_freq=82.41,      # E2
+        fade_in=0.01,
+        fade_out=0.2,
+        tone_freq_ratio=2.0,  # Octave
         tone_mul_factor=0.62,
-        dist_drive=0.35,
-        dist_slope=0.44,
+        dist_drive=0.05,
+        dist_slope=0.1,
         dist_mul_factor=0.56,
+        **kw  # Added **kw to capture any extra args for BasePreset
     ):
-        super().__init__(intensity * 2, duration)
+        if duration == 0: # Ensure duration is not zero
+            duration = 0.001
+        super().__init__(intensity=intensity, duration=duration, **kw) # Use passed intensity, duration
+        
         # core inputs
-        self.base_freq = 1318.2567385564075
+        self.base_freq = base_freq
         # fader constants
-        self.fade_in = 0.0
-        self.fade_out = 0.0
+        self.fade_in = fade_in
+        self.fade_out = fade_out
         # tone constants
-        self.tone_freq_ratio = 223.872113856834
-        self.tone_mul_factor = 0.62
+        self.tone_freq_ratio = tone_freq_ratio
+        self.tone_mul_factor = tone_mul_factor
         # distortion constants
-        self.dist_drive = 0.35
-        self.dist_slope = 0.44
-        self.dist_mul_factor = 0.56
+        self.dist_drive = dist_drive
+        self.dist_slope = dist_slope
+        self.dist_mul_factor = dist_mul_factor
 
     def _build(self):
         # use named attributes everywhere instead of literals
         fader = Fader(
             fadein=self.fade_in,
             fadeout=self.fade_out,
-            dur=self.duration * 2,
+            dur=self.duration, # duration is now correctly passed from super
             mul=self.intensity
         )
         tone = Sine(

--- a/core/audio/presets/drone.py
+++ b/core/audio/presets/drone.py
@@ -1,24 +1,68 @@
 # File: core/audio/presets/drone.py © 2025 projectemergence. All rights reserved.
 #!/usr/bin/env python3
 
-from pyo import Fader, Sine, SigTo
+from pyo import Fader, Sine, Sum
 from core.audio.presets.base_preset import BasePreset
 
-class DronePreset(BasePreset):
-    """Continuous drone whose level & pitch track settled_ratio & visual_metric."""
-    def __init__(self, *, settled_ratio: float = 0.0, visual_metric: float = 0.0,fade_in=0.5,fade_out=0.1,dur=0.89):
-        super().__init__()  # uses default intensity/duration
-        self.settled_ratio = 0.0
-        self.visual_metric = 0.0
-        self.fade_in=0.5
-        self.fade_out=0.1
-        self.dur=0.89
-    def play(self):
-        env  = Fader(fadein=self.fade_in, fadeout=self.fade_out, dur=0.89, mul=self.settled_ratio).play()
-        freq = SigTo(value=200 + self.visual_metric * 800, time=0.1)
-        return Sine(freq=freq, mul=env * 0.3).out()
+class Drone(BasePreset):  # Renamed class
+    """Continuous drone with adjustable complexity."""
+    def __init__(
+        self,
+        intensity=0.4,
+        duration=10.0,
+        base_freq=100.0,
+        complexity=0.2, # Range 0-1
+        fade_in=2.0,
+        fade_out=2.0,
+        lfo_mod_depth_factor=5.0, # New parameter
+        lfo_mod_rate_factor=0.1,  # New parameter
+        **kw
+    ):
+        if duration == 0: # Ensure duration is not zero
+            duration = 0.001 
+        super().__init__(intensity=intensity, duration=duration, **kw)
+        
+        self.base_freq = base_freq
+        self.complexity = complexity # 0-1 range
+        self.fade_in = fade_in
+        self.fade_out = fade_out
+        self.lfo_mod_depth_factor = lfo_mod_depth_factor
+        self.lfo_mod_rate_factor = lfo_mod_rate_factor
+        # self.dur is inherited from BasePreset via super().__init__
+
     def _build(self):
-        # one-liner envelope × drone
-        env = Fader(fadein=self.fade_in, fadeout=self.fade_out, dur=0.89, mul=self.intensity).play()
-        freq = SigTo(value=200 + self.visual_metric * 800, time=0.1)
-        return Sine(freq=freq, mul=env * 0.3)
+        env = Fader(fadein=self.fade_in, fadeout=self.fade_out, dur=self.duration, mul=self.intensity).play()
+        
+        # Main LFO Modulation for primary sine
+        # LFO rate and depth are scaled by complexity
+        lfo_rate = max(0.001, self.complexity * self.lfo_mod_rate_factor)
+        lfo_depth = self.complexity * self.lfo_mod_depth_factor
+        mod_lfo = Sine(freq=lfo_rate, mul=lfo_depth)
+        
+        main_sine_freq = self.base_freq + mod_lfo
+        main_sine = Sine(freq=main_sine_freq, mul=env)
+        
+        output_signal = main_sine
+        
+        # Secondary Oscillator (based on high complexity)
+        if self.complexity > 0.5:
+            detune_factor = 1.0 + (self.complexity - 0.5) * 0.02 
+            secondary_amp_factor = (self.complexity - 0.5) * 0.5 
+            
+            secondary_sine_freq = self.base_freq * detune_factor
+            # Ensure secondary sine also uses the main envelope
+            secondary_sine = Sine(freq=secondary_sine_freq, mul=env * secondary_amp_factor)
+            
+            # Summing the main modulated sine and the secondary sine
+            # Adjust overall gain if necessary, for now simple sum
+            output_signal = Sum([main_sine, secondary_sine], mul=1.0) # mul=1.0 as env already scales them
+
+        self.chain = output_signal # Storing the final output PyoObject
+            
+        return self.chain
+
+    def play(self):
+        # _build now correctly returns the PyoObject (or a chain of them)
+        self.chain_output = self._build()
+        self.chain_output.out()
+        return self.chain_output # Return the Pyo object that is outputting sound

--- a/core/audio/presets/fm_bell_cluster.py
+++ b/core/audio/presets/fm_bell_cluster.py
@@ -12,9 +12,9 @@ class FMBellCluster(BasePreset):
         self,
         intensity=0.6,
         duration=4.0,
-        carrier_freq=330.0,
-        mod_ratio=2.0,
-        index=5.0,
+        carrier_freq=440.0,  # Changed default
+        mod_ratio=1.414,     # Changed default
+        index=3.0,           # Changed default
         chorus_depth=1.2,
         chorus_feedback=0.3,
         reverb_size=0.8,
@@ -25,6 +25,8 @@ class FMBellCluster(BasePreset):
     ):
         kw.setdefault('enable_reverb', True)
         kw.setdefault('stereo_w', 0.2)
+        if duration == 0: # Ensure duration is not zero
+            duration = 0.001
         super().__init__(intensity=intensity, duration=duration, **kw)
 
         # FM params

--- a/core/audio/presets/harmonic_swarm.py
+++ b/core/audio/presets/harmonic_swarm.py
@@ -4,50 +4,56 @@
 HarmonicSwarm – multiple detuned partials with dynamic panning and delay feedback.
 """
 
-from random import uniform
+import random # Added for random.uniform, though 'from random import uniform' was already there
+from random import uniform 
 from pyo import Sine, Fader, Delay, Pan, Sine as LFO
 from core.audio.presets.base_preset import BasePreset
 
 class HarmonicSwarm(BasePreset):
     def __init__(
         self,
-        intensity=0.04,
-        duration=4.7,   
+        intensity=0.3,      # Default changed
+        duration=5.0,       # Default changed
         base_freq=110.0,
         num_voices=6,
         freq_ratio=1.01,
-        pan_rate=0.05,
+        pan_rate=0.02,      # Default changed
         pan_depth=1.0,
         delay_times=(0.1,0.2,0.3),
         delay_feedback=0.3,
         delay_mul=0.4,
-        fade_in=0.005,
-        fade_out=0.01,
+        fade_in=0.5,        # Default changed
+        fade_out=1.5,       # Default changed
+        detune_range=0.005, # New parameter
+        pan_randomness=0.005, # New parameter
         **kw
     ):
         kw.setdefault('enable_reverb', True)
         kw.setdefault('stereo_w', 0.3)
-        if duration==0:
-            duration=1
-        super().__init__(intensity=0.04, duration=4.7, **kw)
+        if duration == 0: # Ensure duration is not zero to prevent errors
+            duration = 0.001 # A very small duration if zero is passed
+        
+        super().__init__(intensity=intensity, duration=duration, **kw) # Use passed intensity and duration
 
         # core
-        self.base_freq = 110.0
-        self.num_voices = 6
-        self.freq_ratio = 1.01
+        self.base_freq = base_freq
+        self.num_voices = num_voices
+        self.freq_ratio = freq_ratio
+        self.detune_range = detune_range       # Store new parameter
+        self.pan_randomness = pan_randomness # Store new parameter
 
         # panning LFO
-        self.pan_rate = 0.05
-        self.pan_depth = 1.0
+        self.pan_rate = pan_rate
+        self.pan_depth = pan_depth
 
         # delay
         self.delay_times = delay_times
-        self.delay_feedback = 0.3
-        self.delay_mul = 0.4
+        self.delay_feedback = delay_feedback
+        self.delay_mul = delay_mul
 
         # envelope
-        self.fade_in = 0.005
-        self.fade_out = 0.01
+        self.fade_in = fade_in
+        self.fade_out = fade_out
 
     def _build(self):
         # long fade for smooth crossfade
@@ -57,10 +63,19 @@ class HarmonicSwarm(BasePreset):
         # create voices
         voices = []
         for i in range(self.num_voices):
-            detune = self.base_freq * (self.freq_ratio**i)
-            osc = Sine(freq=detune, mul=gate/self.num_voices)
-            pan_lfo = LFO(freq=self.pan_rate + uniform(-0.01,0.01),
-                          mul=self.pan_depth/2, add=0.5)
+            # Apply detune randomness
+            current_freq_ratio = self.freq_ratio + random.uniform(-self.detune_range, self.detune_range)
+            actual_freq = self.base_freq * (current_freq_ratio**i) # Renamed 'detune' to 'actual_freq' for clarity
+            
+            osc = Sine(freq=actual_freq, mul=gate/self.num_voices)
+            
+            # Apply pan randomness
+            current_pan_rate = self.pan_rate + random.uniform(-self.pan_randomness, self.pan_randomness)
+            # Ensure pan rate is positive
+            effective_pan_rate = max(0.001, current_pan_rate) 
+            
+            pan_lfo = LFO(freq=effective_pan_rate,
+                          mul=self.pan_depth/2, add=0.5) # uniform(-0.01,0.01) removed as pan_randomness handles it
             voices.append(Pan(osc, pan=pan_lfo))
 
         mix = sum(voices)

--- a/core/audio/presets/laser.py
+++ b/core/audio/presets/laser.py
@@ -9,14 +9,18 @@ class Laser(BasePreset):
         self,
         intensity=0.9,
         duration=0.5,
-        base_freq=800.0,
-        mod_depth=50.0,
-        mod_rate=20.0,
-        fade_in=0.00,
-        fade_out=0.2,
-        fader_mul_factor=1.0,
+        base_freq=300.0,    # Changed default
+        mod_depth=10.0,     # Changed default
+        mod_rate=5.0,       # Changed default
+        fade_in=0.1,        # Changed default
+        fade_out=0.5,       # Changed default
+        fader_mul_factor=1.0, # Keeping this for now, though often intensity alone is enough
+        **kw # Added **kw
     ):
-        super().__init__(intensity, duration)
+        if duration == 0: # Ensure duration is not zero
+            duration = 0.001
+        super().__init__(intensity=intensity, duration=duration, **kw) # Pass intensity, duration
+        
         # core
         self.base_freq = base_freq
         self.mod_depth = mod_depth
@@ -24,7 +28,7 @@ class Laser(BasePreset):
         # envelope settings
         self.fade_in = fade_in
         self.fade_out = fade_out
-        self.fader_mul_factor = fader_mul_factor
+        self.fader_mul_factor = fader_mul_factor # Still here, consider if it's redundant with self.intensity
 
     def _build(self):
         # amplitude envelope


### PR DESCRIPTION
This commit includes the first phase of improvements to the audio engine:

- **Preset & Melody Tracking:**
    - AudioEngineServer now tracks active presets and the current melody.
    - This information is accessible via AudioEngineClient.
    - Automatic cleanup of stopped presets is implemented.

- **Audio Template Standardization (Hyperforest Fractal Style):**
    - All melody JSON files in core/audio/melodies/ have been standardized: - Added rich metadata fields (title, composer, mood, description, poem, tempo, time_signature, structure). - Ensured note data uses the "hands" array structure. - Default intensity added to notes where missing.
    - Refactored 5 core presets (HarmonicSwarm, Drone, Bass, FMBellCluster, Laser):
        - Fixed bugs (e.g., hardcoded parameters in HarmonicSwarm).
        - Adjusted default parameters for better alignment with the "Hyperforest Fractal" aesthetic (clearer, more ambient, less harsh). - Renamed DronePreset to Drone. - Made Drone preset more generic and usable by Maestro.

- **Audio Template Extension:**
    - Extended HarmonicSwarm preset with `detune_range` and `pan_randomness` parameters.
    - Extended Drone preset with more sophisticated LFO modulation based on `complexity`, `lfo_mod_depth_factor`, and `lfo_mod_rate_factor`.
    - Created two new melody variations:
        - Greensleeves_Fast.json (20% faster tempo).
        - Gymnopedie_Quiet.json (30% lower intensity).