### PR TITLE
Handle missing Sum import

### DIFF
--- a/core/audio/presets/drone.py
+++ b/core/audio/presets/drone.py
@@ -1,7 +1,16 @@
 # File: core/audio/presets/drone.py © 2025 projectemergence. All rights reserved.
 #!/usr/bin/env python3
 
-from pyo import Fader, Sine, Sum
+try:
+    from pyo import Fader, Sine, Sum
+except Exception:  # pragma: no cover - fallback when pyo missing or outdated
+    from pyo import Fader, Sine  # type: ignore
+    def Sum(sig_list, mul=1.0):
+        """Basic fallback summing implementation."""
+        out = sig_list[0]
+        for s in sig_list[1:]:
+            out = out + s
+        return out * mul
 from core.audio.presets.base_preset import BasePreset
 
 class Drone(BasePreset):  # Renamed class


### PR DESCRIPTION
## Summary
- allow drone preset to work if pyo.Sum is unavailable

## Testing
- `python -m py_compile AudioUi.py`

------
https://chatgpt.com/codex/tasks/task_e_6845cbdaf6e88328b4e5521b41831e5c