### PR TITLE
Improve logging and preset cleanup

### DIFF
--- a/core/audio/audio_engine_client.py
+++ b/core/audio/audio_engine_client.py
@@ -18,8 +18,11 @@ class AudioEngineClient:
     def __init__(self, *, debug: bool = True):
         # — Logging setup —
         self.logger = logging.getLogger(__name__)
-        if debug:
-            logging.basicConfig(level=logging.DEBUG)
+        if debug and not logging.getLogger().handlers:
+            logging.basicConfig(
+                level=logging.DEBUG,
+                format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
+            )
 
         # — Start a private asyncio loop in a background thread —
         self.loop = asyncio.new_event_loop()


### PR DESCRIPTION
## Summary
- configure logging with timestamps
- handle dict-based preset chains in cleanup logic

## Testing
- `python -m py_compile AudioUi.py core/audio/audio_engine_server.py core/audio/audio_engine_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6852bb2cae108328a799db6587869e65